### PR TITLE
feat #27: 드롭다운 구조에서 트리구조로 변경

### DIFF
--- a/src/main/java/com/nhnacademy/environment/timeseries/controller/BuildTreeController.java
+++ b/src/main/java/com/nhnacademy/environment/timeseries/controller/BuildTreeController.java
@@ -1,0 +1,29 @@
+package com.nhnacademy.environment.timeseries.controller;
+
+import com.nhnacademy.environment.timeseries.domain.TreeNode;
+import com.nhnacademy.environment.timeseries.dto.TreeNodeDto;
+import com.nhnacademy.environment.timeseries.service.BuildTreeService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/environment/{companyDomain}")
+@RequiredArgsConstructor
+public class BuildTreeController {
+
+    private final BuildTreeService buildTreeService;
+
+    @GetMapping("/tree")
+    public TreeNodeDto getTree(@PathVariable String companyDomain) {
+        TreeNode tree = buildTreeService.buildTree(companyDomain);
+        log.debug("반환되는 트리구조: {}", tree);
+        return buildTreeService.convertToDto(tree);
+    }
+
+}

--- a/src/main/java/com/nhnacademy/environment/timeseries/controller/TimeSeriesDataController.java
+++ b/src/main/java/com/nhnacademy/environment/timeseries/controller/TimeSeriesDataController.java
@@ -70,7 +70,7 @@ public class TimeSeriesDataController {
      *
      * @param companyDomain 회사 도메인
      * @param tag           조회할 태그 명 (예: location)
-     * @param origin        데이터 출처
+     * @param filters        데이터 출처
      * @return 해당 태그의 고유 값 리스트
      */
     @GetMapping("/dropdown/{tag}")
@@ -78,9 +78,10 @@ public class TimeSeriesDataController {
     public List<String> getTagDropdown(
             @PathVariable String companyDomain,
             @PathVariable String tag,
-            @RequestParam String origin
+            @RequestParam Map<String, String> filters
     ) {
-        return timeSeriesDataService.getTagValues(tag, Map.of("origin", origin, "companyDomain", companyDomain));
+        filters.put("companyDomain", companyDomain);
+        return timeSeriesDataService.getTagValues(tag, filters);
     }
 
     /**
@@ -88,22 +89,16 @@ public class TimeSeriesDataController {
      * origin, location, companyDomain 필터에 따라 InfluxDB에서 중복 제거된 측정 항목 목록을 반환합니다.
      *
      * @param companyDomain 회사 도메인
-     * @param origin        데이터 출처 (예: sensor_data, server_data)
-     * @param gatewayId      선택적 위치 필터 (예: cpu, memory 등)
+     * @param filters        companyDomain 을 제외한 influxdb 태그
      * @return 중복 제거된 _measurement 리스트 (예: usage_idle, battery 등)
      */
     @GetMapping("/measurements")
     //@HasRole({"ROLE_ADMIN", "ROLE_OWNER", "ROLE_USER"})
     public List<String> getMeasurements(
             @PathVariable String companyDomain,
-            @RequestParam String origin,
-            @RequestParam String gatewayId
+            @RequestParam Map<String, String> filters
     ) {
-        Map<String, String> filters = new HashMap<>();
-        filters.put("origin", origin);
         filters.put("companyDomain", companyDomain);
-        filters.put("gatewayId", gatewayId);
-
         return timeSeriesDataService.getMeasurementList(filters);
     }
 

--- a/src/main/java/com/nhnacademy/environment/timeseries/domain/TreeNode.java
+++ b/src/main/java/com/nhnacademy/environment/timeseries/domain/TreeNode.java
@@ -1,0 +1,44 @@
+package com.nhnacademy.environment.timeseries.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class TreeNode {
+
+    /**
+     * 노드 이름 (예: building, location, origin, deviceId 등).
+     */
+    private String label;
+
+    /**
+     * 태그 유형 (예: building, location, origin, deviceId 등).
+     */
+    private String tag;
+
+    /**
+     * 하위 노드 목록.
+     */
+    private List<TreeNode> children = new ArrayList<>();
+
+    public TreeNode(String label, String tag) {
+        this.label = label;
+        this.tag = tag;
+    }
+
+    public void addChild(TreeNode child) {
+        children.add(child);
+    }
+}

--- a/src/main/java/com/nhnacademy/environment/timeseries/dto/TreeNodeDto.java
+++ b/src/main/java/com/nhnacademy/environment/timeseries/dto/TreeNodeDto.java
@@ -1,0 +1,28 @@
+package com.nhnacademy.environment.timeseries.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TreeNodeDto {
+
+    /**
+     * 노드 이름 (예: building, location, origin, deviceId 등).
+     */
+    private String label;
+
+    /**
+     * 태그 유형 (예: building, location, origin, deviceId 등).
+     */
+    private String tag;
+
+    /**
+     * 하위 노드 목록.
+     */
+    private List<TreeNodeDto> children;
+}

--- a/src/main/java/com/nhnacademy/environment/timeseries/service/BuildTreeService.java
+++ b/src/main/java/com/nhnacademy/environment/timeseries/service/BuildTreeService.java
@@ -1,0 +1,56 @@
+package com.nhnacademy.environment.timeseries.service;
+
+import com.nhnacademy.environment.timeseries.domain.TreeNode;
+import com.nhnacademy.environment.timeseries.dto.TreeNodeDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BuildTreeService {
+
+    private final TimeSeriesDataService timeSeriesDataService;
+
+    public TreeNode buildTree(String companyDomain) {
+        TreeNode root = new TreeNode("root", "root");
+        Map<String, String> baseFilters = Map.of("companyDomain", companyDomain);
+
+        List<String> tagLevels = List.of("building", "origin", "location", "deviceId", "place", "gatewayId", "measurement");
+
+        buildRecursive(root, tagLevels, 0, baseFilters);
+
+        log.debug("최종 트리: {}", root);
+        return root;
+    }
+
+    private void buildRecursive(TreeNode parent, List<String> tagLevels, int level, Map<String, String> filters) {
+        if (level >= tagLevels.size()) return;
+
+        String currentTag = tagLevels.get(level);
+        List<String> values = timeSeriesDataService.getTagValues(currentTag, filters);
+
+        for (String value : values) {
+            TreeNode child = new TreeNode(value, currentTag);
+            parent.addChild(child);
+
+            // 다음 필터 조건에 현재 값을 포함시켜서 하위 노드 구성
+            Map<String, String> nextFilters = new java.util.HashMap<>(filters);
+            nextFilters.put(currentTag, value);
+
+            buildRecursive(child, tagLevels, level + 1, nextFilters);
+        }
+    }
+
+    public TreeNodeDto convertToDto (TreeNode node) {
+        List<TreeNodeDto> childDtos = node.getChildren().stream()
+                .map(this::convertToDto)
+                .toList();
+
+        return new TreeNodeDto(node.getLabel(), node.getTag(), childDtos);
+    }
+}

--- a/src/main/java/com/nhnacademy/environment/timeseries/service/TimeSeriesDataService.java
+++ b/src/main/java/com/nhnacademy/environment/timeseries/service/TimeSeriesDataService.java
@@ -69,7 +69,9 @@ public class TimeSeriesDataService {
         flux.append(String.format(" |> filter(fn: (r) => r[\"origin\"] == \"%s\")", origin));
 
         allParams.forEach((key, value) -> {
-            if (!key.equals("origin") && value != null && !value.isBlank()) {
+            if (!key.equals("origin") &&
+                    !key.equals("measurement") && // influxdb 에서 measurement 없어질 때 까지 임시로 쿼리에서 제거
+                    value != null && !value.isBlank()) {
                 flux.append(String.format(" |> filter(fn: (r) => r[\"%s\"] == \"%s\")", key, value));
             }
         });


### PR DESCRIPTION
백엔드에서 데이터 계층을 설정해 트리를 Map 형태로 프론트에 보냅니다.

BuildTreeService 의 메서드의 역할은 다음과 같습니다.

1. buildTree 
지정된 companyDomain 을 기반으로 InfluxDB에 저장된 시계열 데이터의 태그(building, origin, location, 등)를 계층적으로 탐색하여, TreeNode 구조로 구성된 트리를 생성합니다.

2. buildRecursive
buildTree에서 정의된 태그 계층(tagLevels)을 기준으로, 이 메서드는 각 태그를 탐색하여 TreeNode 트리를 구성합니다.

3. convertToDto
트리 구조의 도메인 객체 TreeNode를 DTO(TreeNodeDto)로 재귀적으로 변환하여, 프론트엔드에서 사용할 수 있는 형태로 반환합니다.

현재는 TreeNode 도메인과 TreeNodeDto 가 동일한 형태지만, 추후 다른 서비스의 트리를 생성해야 하는 경우 확장성을 고려해 DTO 를 별도로 지정했습니다.

이상입니다.